### PR TITLE
Auto add overlays

### DIFF
--- a/src/main/kotlin/com/aliucord/gradle/task/CompileResourcesTask.kt
+++ b/src/main/kotlin/com/aliucord/gradle/task/CompileResourcesTask.kt
@@ -64,6 +64,7 @@ abstract class CompileResourcesTask : Exec() {
             args("-R", tmpRes.path)
             args("--manifest", manifestFile.asFile.get().path)
             args("-o", outputFile.asFile.get().path)
+            args("--auto-add-overlay")
             execute()
         }
 


### PR DESCRIPTION
Solves an issue with adding `values` resources, that was causing `error: failed to merge resource table. error: failed parsing overlays.`