### PR TITLE
fix: migrate from rawgithub to jsdelivr

### DIFF
--- a/src/main/kotlin/com/aliucord/gradle/AliucordPluginExtension.kt
+++ b/src/main/kotlin/com/aliucord/gradle/AliucordPluginExtension.kt
@@ -127,8 +127,8 @@ public abstract class AliucordExtension @Inject constructor(private val project:
         if (!updateUrl.isPresent && !buildUrl.isPresent) {
             val repo = repoUrl.removePrefix("https://github.com/")
 
-            updateUrl.set("https://raw.githubusercontent.com/$repo/refs/heads/builds/updater.json")
-            buildUrl.set("https://raw.githubusercontent.com/$repo/refs/heads/builds/${project.name}.zip")
+            updateUrl.set("https://cdn.jsdelivr.net/gh/$repo@refs/heads/builds/updater.json")
+            buildUrl.set("https://cdn.jsdelivr.net/gh/$repo@refs/heads/builds/${project.name}.zip")
         }
     }
 


### PR DESCRIPTION
Migrates raw.githubusercontent.com urls to cdn.jsdelivr.net to solve all `429: Too Many Requests` errors on CGNAT networks after recent GitHub rate limit enforcements.