### PR TITLE
fix(Injector): make `deployOnAdb` task depend on `compileDex` task

### DIFF
--- a/src/main/kotlin/com/aliucord/gradle/plugins/AliucordInjectorGradle.kt
+++ b/src/main/kotlin/com/aliucord/gradle/plugins/AliucordInjectorGradle.kt
@@ -49,7 +49,7 @@ public abstract class AliucordInjectorGradle : AliucordBaseGradle() {
         project.tasks.register<DeployComponentTask>("deployWithAdb") {
             group = Constants.TASK_GROUP
             componentType = "injector"
-            componentFile.fileProvider(compileDexTask.map { it.outputs.files.asFileTree.singleFile })
+            componentFile.fileProvider(compileDexTask.map { it.outputs.files.singleFile })
             componentVersion = project.version.toString()
         }
     }

--- a/src/main/kotlin/com/aliucord/gradle/plugins/AliucordInjectorGradle.kt
+++ b/src/main/kotlin/com/aliucord/gradle/plugins/AliucordInjectorGradle.kt
@@ -49,7 +49,7 @@ public abstract class AliucordInjectorGradle : AliucordBaseGradle() {
         project.tasks.register<DeployComponentTask>("deployWithAdb") {
             group = Constants.TASK_GROUP
             componentType = "injector"
-            componentFile.fileProvider(compileDexTask.map { it.outputs.files.singleFile })
+            componentFile.fileProvider(compileDexTask.map { it.outputs.files.asFileTree.singleFile })
             componentVersion = project.version.toString()
         }
     }

--- a/src/main/kotlin/com/aliucord/gradle/plugins/AliucordInjectorGradle.kt
+++ b/src/main/kotlin/com/aliucord/gradle/plugins/AliucordInjectorGradle.kt
@@ -47,6 +47,7 @@ public abstract class AliucordInjectorGradle : AliucordBaseGradle() {
 
         // Deployment
         project.tasks.register<DeployComponentTask>("deployWithAdb") {
+            dependsOn += compileDexTask
             group = Constants.TASK_GROUP
             componentType = "injector"
             componentFile.fileProvider(compileDexTask.map { it.outputs.files.asFileTree.singleFile })


### PR DESCRIPTION
Executing 'deployOnAdb' task on Injector for the first time (or after wiping cache) fails because Gradle tries to retrieve `compileDex` task output too early. This PR should fix that.