### PR TITLE
fix(ci): publish snapshots only if secrets exist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Build & Publish Snapshot
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         shell: bash
         env:
           MAVEN_SNAPSHOTS_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,20 +23,21 @@ jobs:
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
-      - name: Build & Publish Snapshot
-        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+      - name: Build & Publish to Maven Local
         shell: bash
-        env:
-          MAVEN_SNAPSHOTS_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_SNAPSHOTS_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        run: |
-          chmod +x ./gradlew
-          ./gradlew --stacktrace :publishToMavenLocal :publishAllPublicationsToAliucordSnapshotsRepository -PVERSION_NAME=${GITHUB_SHA::7}
+        run: ./gradlew --stacktrace :publishToMavenLocal
 
       - name: Upload artifacts
-        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v4
         with:
           name: gradle-plugin
           path: ~/.m2/repository/**
           if-no-files-found: error
+
+      - name: Publish Snapshot
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+        shell: bash
+        env:
+          MAVEN_SNAPSHOTS_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_SNAPSHOTS_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        run: ./gradlew :publishAllPublicationsToAliucordSnapshotsRepository -PVERSION_NAME=${GITHUB_SHA::7}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
           ./gradlew --stacktrace :publishToMavenLocal :publishAllPublicationsToAliucordSnapshotsRepository -PVERSION_NAME=${GITHUB_SHA::7}
 
       - name: Upload artifacts
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v4
         with:
           name: gradle-plugin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
           if-no-files-found: error
 
       - name: Publish Snapshot
-        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         shell: bash
         env:
           MAVEN_SNAPSHOTS_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_SNAPSHOTS_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        if: ${{ env.MAVEN_SNAPSHOTS_USERNAME != '' && env.MAVEN_SNAPSHOTS_PASSWORD != '' }}
         run: ./gradlew :publishAllPublicationsToAliucordSnapshotsRepository -PVERSION_NAME=${GITHUB_SHA::7}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,12 @@ jobs:
           if-no-files-found: error
 
       - name: Publish Snapshot
-        shell: bash
+        if: ${{ github.event_name != 'pull_request'
+          && env.MAVEN_SNAPSHOTS_USERNAME != ''
+          && env.MAVEN_SNAPSHOTS_PASSWORD != '' }}
         env:
-          MAVEN_SNAPSHOTS_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_SNAPSHOTS_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        if: ${{ env.MAVEN_SNAPSHOTS_USERNAME != '' && env.MAVEN_SNAPSHOTS_PASSWORD != '' }}
-        run: ./gradlew :publishAllPublicationsToAliucordSnapshotsRepository -PVERSION_NAME=${GITHUB_SHA::7}
+          MAVEN_SNAPSHOTS_USERNAME: ${{ secrets.MAVEN_SNAPSHOTS_USERNAME }}
+          MAVEN_SNAPSHOTS_PASSWORD: ${{ secrets.MAVEN_SNAPSHOTS_PASSWORD }}
+        run: |
+          ./gradlew --stacktrace -PVERSION_NAME=$(git rev-parse --short "$GITHUB_SHA") \
+              :publishAllPublicationsToAliucordSnapshotsRepository


### PR DESCRIPTION
Just makes it so snapshots are only published when secrets are defined. This prevents the workflow from failing for forks